### PR TITLE
flash_writer_tool: wait before writing FLASHWRITER

### DIFF
--- a/flash_writer_tool.sh
+++ b/flash_writer_tool.sh
@@ -1743,6 +1743,7 @@ if [ "$CMD" == "fw" ] ; then
 	if [ "$BOARD" == "rzt2h-dev" ] ; then
 		echo "Sending HDR NM"
 		echo -en "S0090000484452204E4D5D" > $SERIAL_DEVICE_INTERFACE
+		sleep 1
 	fi
 
 	echo "Sending Flash Writter Binary ($FLASHWRITER)"


### PR DESCRIPTION
RZ/T2H and RZ/N2H platforms require a special header to be written before the FLASHWRITER.

Give SCI a chance to handle the special header and to put itself into program loading mode by waiting for 1 second.

The maximum delay for the FLASHWRITER file to start being written is 10 seconds, as described in the BSP docs.